### PR TITLE
More strict check for init["baseURL"] in URLPatternInit processing

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1807,7 +1807,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   1. Set |result|["{{URLPatternInit/search}}"] to |search|.
   1. Set |result|["{{URLPatternInit/hash}}"] to |hash|.
   1. Let |baseURL| be null.
-  1. If |init|["{{URLPatternInit/baseURL}}"] [=map/exists=]:
+  1. If |init|["{{URLPatternInit/baseURL}}"] [=map/exists=] and is a non-empty string:
     <div class="note">
       The base URL can be used to supply additional context, but for each component, if |init| includes a component which is at least as specific as one in the base URL, none is inherited.
 


### PR DESCRIPTION
`init["baseURL"]` is initialized with null, and [map-exists](https://infra.spec.whatwg.org/#map-exists) only checks if there exists an entry with the key. This commit adds null or empty string check for `init["baseURL"]` in URLPatternInit processing.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Google Chrome
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * n/a (this is a fix to how the spec expresses this, but does not represent a behavior change, and existing tests cover this behavior)
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: n/a (believed to work correctly in Chromium)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1731418 (vendor does not yet implement the spec)
   * WebKit: [no known URLPattern bug] (vendor does not yet implement the spec)
   * Deno: n/a (no reason to believe a change is required)
   * kenchris/urlpattern-polyfill: n/a (no reason to believe a change is required)
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (change is on a spec detail not expressly documented)
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/205.html" title="Last updated on Jan 15, 2024, 7:47 AM UTC (f00b3d6)">Preview</a> | <a href="https://whatpr.org/urlpattern/205/531a2cc...f00b3d6.html" title="Last updated on Jan 15, 2024, 7:47 AM UTC (f00b3d6)">Diff</a>