### PR TITLE
Do not initialize members to null in "process a URLPatternInit"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1801,14 +1801,14 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>process a URLPatternInit</dfn> given a {{URLPatternInit}} |init|, a string |type|, a string or null |protocol|, a string or null |username|, a string or null |password|, a string or null |hostname|, a string or null |port|, a string or null |pathname|, a string or null |search|, and a string or null |hash|:
 
   1. Let |result| be the result of creating a new {{URLPatternInit}}.
-  1. Set |result|["{{URLPatternInit/protocol}}"] to |protocol|.
-  1. Set |result|["{{URLPatternInit/username}}"] to |username|.
-  1. Set |result|["{{URLPatternInit/password}}"] to |password|.
-  1. Set |result|["{{URLPatternInit/hostname}}"] to |hostname|.
-  1. Set |result|["{{URLPatternInit/port}}"] to |port|.
-  1. Set |result|["{{URLPatternInit/pathname}}"] to |pathname|.
-  1. Set |result|["{{URLPatternInit/search}}"] to |search|.
-  1. Set |result|["{{URLPatternInit/hash}}"] to |hash|.
+  1. If |protocol| is not null, set |result|["{{URLPatternInit/protocol}}"] to |protocol|.
+  1. If |username| is not null, set |result|["{{URLPatternInit/username}}"] to |username|.
+  1. If |password| is not null, set |result|["{{URLPatternInit/password}}"] to |password|.
+  1. If |hostname| is not null, set |result|["{{URLPatternInit/hostname}}"] to |hostname|.
+  1. If |port| is not null, set |result|["{{URLPatternInit/port}}"] to |port|.
+  1. If |pathname| is not null, set |result|["{{URLPatternInit/pathname}}"] to |pathname|.
+  1. If |search| is not null, set |result|["{{URLPatternInit/search}}"] to |search|.
+  1. If |hash| is not null, set |result|["{{URLPatternInit/hash}}"] to |hash|.
   1. Let |baseURL| be null.
   1. If |init|["{{URLPatternInit/baseURL}}"] [=map/exists=]:
     <div class="note">


### PR DESCRIPTION
It is not valid for these dictionary members to be null, since they are defined to, if present, hold a USVString value. Instead, these should be omitted from the result dictionary altogether if no string was provided to this algorithm.

This addresses the concern raised in https://github.com/whatwg/urlpattern/issues/202#issuecomment-1893280263.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Google Chrome
   * n/a (change is simply fixing a bug in a non-controversial way, per [this comment](https://github.com/whatwg/urlpattern/pull/203#issuecomment-1893134462))
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * n/a (this is a fix to how the spec expresses this, but does not represent a behavior change, and existing tests cover this behavior)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: n/a (believed to work correctly in Chromium)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1731418 (vendor does not yet implement the spec)
   * WebKit: [no known URLPattern bug] (vendor does not yet implement the spec)
   * Deno: n/a (no reason to believe a change is required)
   * kenchris/urlpattern-polyfill: n/a (no reason to believe a change is required)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (change is on a spec detail not expressly documented)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
