### PR TITLE
Do not initialize a URLPatternInit member to null in "initialize a URLPattern"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -354,7 +354,7 @@ Each {{URLPattern}} object has an associated <dfn for=URLPattern>hash component<
   1. If |input| is a [=scalar value string=] then:
     1. Set |init| to the result of running [=parse a constructor string=] given |input|.
     1. If |baseURL| is null and |init|["{{URLPatternInit/protocol}}"] does not [=map/exist=], then throw a {{TypeError}}.
-    1. Set |init|["{{URLPatternInit/baseURL}}"] to |baseURL|.
+    1. If |baseURL| is not null, set |init|["{{URLPatternInit/baseURL}}"] to |baseURL|.
   1. Otherwise:
     1. [=Assert=]: |input| is a {{URLPatternInit}}.
     1. If |baseURL| is not null, then throw a {{TypeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -354,7 +354,7 @@ Each {{URLPattern}} object has an associated <dfn for=URLPattern>hash component<
   1. If |input| is a [=scalar value string=] then:
     1. Set |init| to the result of running [=parse a constructor string=] given |input|.
     1. If |baseURL| is null and |init|["{{URLPatternInit/protocol}}"] does not [=map/exist=], then throw a {{TypeError}}.
-    1. If |baseURL| is not null, set |init|["{{URLPatternInit/baseURL}}"] to |baseURL|.
+    1. If |baseURL| is not null, [=map/set=] |init|["{{URLPatternInit/baseURL}}"] to |baseURL|.
   1. Otherwise:
     1. [=Assert=]: |input| is a {{URLPatternInit}}.
     1. If |baseURL| is not null, then throw a {{TypeError}}.


### PR DESCRIPTION
It is not valid for the baseURL dictionary member to be null, only either absent or a USVString. Instead, this should be omitted from the dictionary altogether if no string was provided to this algorithm.

Any string which is invalid will fail later on, when it is to be parsed as a URL.

Fixes #204.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Google Chrome
   * n/a (change is simply fixing a bug in a non-controversial way, per [this comment](https://github.com/whatwg/urlpattern/pull/203#issuecomment-1893134462))
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * n/a (this is a fix to how the spec expresses this, but does not represent a behavior change, and existing tests cover this behavior)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: n/a (believed to work correctly in Chromium)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1731418 (vendor does not yet implement the spec)
   * WebKit: [no known URLPattern bug] (vendor does not yet implement the spec)
   * Deno: n/a (no reason to believe a change is required)
   * kenchris/urlpattern-polyfill: n/a (no reason to believe a change is required)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (change is on a spec detail not expressly documented)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 26, 2024, 5:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Furlpattern%2F226dee4d836b2f5e54e2e8e5ad4b358f37df9b0c%2Fspec.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20213)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/urlpattern%23213.)._
</details>
