### PR TITLE
Make the match algorithm accept the URL struct

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -11,6 +11,7 @@ Markup Shorthands: markdown yes
 <pre class="link-defaults">
 spec:infra; type:dfn; text:list
 spec:webidl; type:dfn; text:record
+spec:url; type:interface; text:URL
 </pre>
 
 <pre class="anchors">
@@ -21,6 +22,15 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
     text: serialize an integer; url: #serialize-an-integer
+    text: url; url: #concept-url
+    text: scheme; for: url; url: #concept-url-scheme
+    text: username; for: url; url: #concept-url-username
+    text: password; for: url; url: #concept-url-password
+    text: host; for: url; url: #concept-url-host
+    text: port; for: url; url: #concept-url-port
+    text: path; for: url; url: #concept-url-path
+    text: query; for: url; url: #concept-url-query
+    text: fragment; for: url; url: #concept-url-fragment
 </pre>
 
 <h2 id=urlpatterns>URL patterns</h2>
@@ -171,15 +181,16 @@ It can be constructed using a string for each component, or from a shorthand str
 
 <xmp class="idl">
 typedef (USVString or URLPatternInit) URLPatternInput;
+typedef (URLPatternInput or URL) URLPatternMatchInput;
 
 [Exposed=(Window,Worker)]
 interface URLPattern {
   constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
   constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});
 
-  boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
+  boolean test(optional URLPatternMatchInput input = {}, optional USVString baseURL);
 
-  URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
+  URLPatternResult? exec(optional URLPatternMatchInput input = {}, optional USVString baseURL);
 
   readonly attribute USVString protocol;
   readonly attribute USVString username;
@@ -468,7 +479,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
 </div>
 
 <div algorithm>
-  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternInput}} |input|, and an optional string |baseURLString|:
+  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternMatchInput}} |input|, and an optional string |baseURLString|:
 
   1. Let |protocol| be the empty string.
   1. Let |username| be the empty string.
@@ -480,7 +491,17 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Let |hash| be the empty string.
   1. Let |inputs| be an empty [=list=].
   1. [=list/Append=] |input| to |inputs|.
-  1. If |input| is a {{URLPatternInit}} then:
+  1. If |input| is a {{URL}} then:
+    1. Let |associatedUrl| be |input|'s associated [=URL=].
+    1. Set |protocol| to |associatedUrl|'s [=url/scheme=].
+    1. Set |username| to |associatedUrl|'s [=url/username=].
+    1. Set |password| to |associatedUrl|'s [=url/password=].
+    1. Set |hostname| to |associatedUrl|'s [=url/host=].
+    1. Set |port| to |associatedUrl|'s [=url/port=].
+    1. Set |pathname| to |associatedUrl|'s [=url/path=].
+    1. Set |search| to |associatedUrl|'s [=url/query=].
+    1. Set |hash| to |associatedUrl|'s [=url/fragment=].
+  1. Else if |input| is a {{URLPatternInit}} then:
     1. If |baseURLString| was given, throw a {{TypeError}}.
     1. Let |applyResult| be the result of [=process a URLPatternInit=] given |input|, "url", |protocol|, |username|, |password|, |hostname|, |port|, |pathname|, |search|, and |hash|. If this throws an exception, catch it, and return null.
     1. Set |protocol| to |applyResult|["{{URLPatternInit/protocol}}"].
@@ -491,7 +512,8 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. Set |pathname| to |applyResult|["{{URLPatternInit/pathname}}"].
     1. Set |search| to |applyResult|["{{URLPatternInit/search}}"].
     1. Set |hash| to |applyResult|["{{URLPatternInit/hash}}"].
-  1. Otherwise:
+  1. Else:
+    1. [=Assert=]: |input| is a {{USVString}}.
     1. Let |baseURL| be null.
     1. If |baseURLString| was given, then:
       1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.

--- a/spec.bs
+++ b/spec.bs
@@ -501,7 +501,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
         1. [=list/Append=] |baseURLString| to |inputs|.
       1. Set |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
       1. If |url| is failure, return null.
-    1. [=Assert=]: |url| is [=/url=]
+    1. [=Assert=]: |url| is a [=/URL=].
     1. Set |protocol| to |url|'s [=url/scheme=].
     1. Set |username| to |url|'s [=url/username=].
     1. Set |password| to |url|'s [=url/password=].

--- a/spec.bs
+++ b/spec.bs
@@ -468,7 +468,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
 </div>
 
 <div algorithm>
-  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternInput}} or [=/url=] |input|, and an optional string |baseURLString|:
+  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternInput}} or [=/URL=] |input|, and an optional string |baseURLString|:
 
   1. Let |protocol| be the empty string.
   1. Let |username| be the empty string.

--- a/spec.bs
+++ b/spec.bs
@@ -11,7 +11,6 @@ Markup Shorthands: markdown yes
 <pre class="link-defaults">
 spec:infra; type:dfn; text:list
 spec:webidl; type:dfn; text:record
-spec:url; type:interface; text:URL
 </pre>
 
 <pre class="anchors">
@@ -22,15 +21,6 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
     text: serialize an integer; url: #serialize-an-integer
-    text: url; url: #concept-url
-    text: scheme; for: url; url: #concept-url-scheme
-    text: username; for: url; url: #concept-url-username
-    text: password; for: url; url: #concept-url-password
-    text: host; for: url; url: #concept-url-host
-    text: port; for: url; url: #concept-url-port
-    text: path; for: url; url: #concept-url-path
-    text: query; for: url; url: #concept-url-query
-    text: fragment; for: url; url: #concept-url-fragment
 </pre>
 
 <h2 id=urlpatterns>URL patterns</h2>
@@ -181,16 +171,15 @@ It can be constructed using a string for each component, or from a shorthand str
 
 <xmp class="idl">
 typedef (USVString or URLPatternInit) URLPatternInput;
-typedef (URLPatternInput or URL) URLPatternMatchInput;
 
 [Exposed=(Window,Worker)]
 interface URLPattern {
   constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
   constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});
 
-  boolean test(optional URLPatternMatchInput input = {}, optional USVString baseURL);
+  boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
 
-  URLPatternResult? exec(optional URLPatternMatchInput input = {}, optional USVString baseURL);
+  URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
 
   readonly attribute USVString protocol;
   readonly attribute USVString username;
@@ -479,7 +468,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
 </div>
 
 <div algorithm>
-  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternMatchInput}} |input|, and an optional string |baseURLString|:
+  To perform a <dfn export for="URL pattern">match</dfn> given a [=URL pattern=] |urlPattern|, a {{URLPatternInput}} or [=/url=] |input|, and an optional string |baseURLString|:
 
   1. Let |protocol| be the empty string.
   1. Let |username| be the empty string.
@@ -491,17 +480,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Let |hash| be the empty string.
   1. Let |inputs| be an empty [=list=].
   1. [=list/Append=] |input| to |inputs|.
-  1. If |input| is a {{URL}} then:
-    1. Let |associatedUrl| be |input|'s associated [=URL=].
-    1. Set |protocol| to |associatedUrl|'s [=url/scheme=].
-    1. Set |username| to |associatedUrl|'s [=url/username=].
-    1. Set |password| to |associatedUrl|'s [=url/password=].
-    1. Set |hostname| to |associatedUrl|'s [=url/host=].
-    1. Set |port| to |associatedUrl|'s [=url/port=].
-    1. Set |pathname| to |associatedUrl|'s [=url/path=].
-    1. Set |search| to |associatedUrl|'s [=url/query=].
-    1. Set |hash| to |associatedUrl|'s [=url/fragment=].
-  1. Else if |input| is a {{URLPatternInit}} then:
+  1. If |input| is a {{URLPatternInit}} then:
     1. If |baseURLString| was given, throw a {{TypeError}}.
     1. Let |applyResult| be the result of [=process a URLPatternInit=] given |input|, "url", |protocol|, |username|, |password|, |hostname|, |port|, |pathname|, |search|, and |hash|. If this throws an exception, catch it, and return null.
     1. Set |protocol| to |applyResult|["{{URLPatternInit/protocol}}"].
@@ -512,15 +491,17 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. Set |pathname| to |applyResult|["{{URLPatternInit/pathname}}"].
     1. Set |search| to |applyResult|["{{URLPatternInit/search}}"].
     1. Set |hash| to |applyResult|["{{URLPatternInit/hash}}"].
-  1. Else:
-    1. [=Assert=]: |input| is a {{USVString}}.
-    1. Let |baseURL| be null.
-    1. If |baseURLString| was given, then:
-      1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.
-      1. If |baseURL| is failure, return null.
-      1. [=list/Append=] |baseURLString| to |inputs|.
-    1. Let |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
-    1. If |url| is failure, return null.
+  1. Otherwise:
+    1. Let |url| be |input|.
+    1. If |input| is a {{USVString}}:
+      1. Let |baseURL| be null.
+      1. If |baseURLString| was given, then:
+        1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.
+        1. If |baseURL| is failure, return null.
+        1. [=list/Append=] |baseURLString| to |inputs|.
+      1. Let |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
+      1. If |url| is failure, return null.
+    1. [=Assert=]: |url| is [=/url=]
     1. Set |protocol| to |url|'s [=url/scheme=].
     1. Set |username| to |url|'s [=url/username=].
     1. Set |password| to |url|'s [=url/password=].

--- a/spec.bs
+++ b/spec.bs
@@ -499,7 +499,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
         1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.
         1. If |baseURL| is failure, return null.
         1. [=list/Append=] |baseURLString| to |inputs|.
-      1. Let |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
+      1. Set |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
       1. If |url| is failure, return null.
     1. [=Assert=]: |url| is [=/url=]
     1. Set |protocol| to |url|'s [=url/scheme=].

--- a/spec.bs
+++ b/spec.bs
@@ -499,7 +499,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
         1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.
         1. If |baseURL| is failure, return null.
         1. [=list/Append=] |baseURLString| to |inputs|.
-      1. Set |url| be the result of [=URL parser|parsing=] |input| given |baseURL|.
+      1. Set |url| to the result of [=URL parser|parsing=] |input| given |baseURL|.
       1. If |url| is failure, return null.
     1. [=Assert=]: |url| is a [=/URL=].
     1. Set |protocol| to |url|'s [=url/scheme=].


### PR DESCRIPTION
In https://github.com/w3c/ServiceWorker/pull/1701, the ServiceWorker static routing API uses the match algorithm to match the request URL.  However, the original match algorithm accepts a URLPatternInput object, and it does not accept a URL struct.  To allow the ServiceWorker static routing API to use the match algorithm, we need to make the match algorithm to accept the URL struct.

Fixes: https://github.com/whatwg/urlpattern/issues/218.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
  This is a part of the ServiceWorker static routing API.
   * Google Chrome
   * Firefox
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * n/a (this is just clarifying an implicit behavior.  There is no actual behavior change.)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: n/a (no behavior change is required)
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1855580 (vendor does not yet implement the spec)
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=269893 (vendor does not yet implement the spec)
   * Deno: n/a (no reason to believe a change is required)
   * kenchris/urlpattern-polyfill: n/a (no reason to believe a change is required)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (change is on a spec detail not expressly documented)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/221.html" title="Last updated on Feb 28, 2024, 11:38 PM UTC (483bccb)">Preview</a> | <a href="https://whatpr.org/urlpattern/221/69ccf3a...483bccb.html" title="Last updated on Feb 28, 2024, 11:38 PM UTC (483bccb)">Diff</a>