### PR TITLE
Editorial: Add proper serialization of URL properties

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -22,7 +22,6 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
     text: serialize an integer; url: #serialize-an-integer
     text: host serializer; url: #concept-host-serializer
-
 </pre>
 
 <h2 id=urlpatterns>URL patterns</h2>

--- a/spec.bs
+++ b/spec.bs
@@ -1748,7 +1748,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
 <div algorithm>
   To <dfn>canonicalize a port</dfn> given a string |portValue| and optionally a string |protocolValue|:
 
-  1. If |value| is the empty string, return |value|.
+  1. If |portValue| is the empty string, return |portValue|.
   1. Let |dummyURL| be a new [=URL record=].
   1. If |protocolValue| was given, then set |dummyURL|'s [=url/scheme=] to |protocolValue|.
      <p class="note">Note, we set the [=URL record=]'s [=url/scheme=] in order for the [=basic URL parser=] to recognize and normalize default port values.</p>

--- a/spec.bs
+++ b/spec.bs
@@ -21,6 +21,8 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 spec: URL; urlPrefix: https://url.spec.whatwg.org/
   type: dfn
     text: serialize an integer; url: #serialize-an-integer
+    text: host serializer; url: #concept-host-serializer
+
 </pre>
 
 <h2 id=urlpatterns>URL patterns</h2>
@@ -505,8 +507,8 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. Set |protocol| to |url|'s [=url/scheme=].
     1. Set |username| to |url|'s [=url/username=].
     1. Set |password| to |url|'s [=url/password=].
-    1. Set |hostname| to |url|'s [=url/host=] or the empty string if the value is null.
-    1. Set |port| to |url|'s [=url/port=] or the empty string if the value is null.
+    1. Set |hostname| to |url|'s [=url/host=], [=host serializer|serialized=], or the empty string if the value is null.
+    1. Set |port| to |url|'s [=url/port=], [=serialize an integer|serialized=], or the empty string if the value is null.
     1. Set |pathname| to the result of [=URL path serializing=] |url|.
     1. Set |search| to |url|'s [=url/query=] or the empty string if the value is null.
     1. Set |hash| to |url|'s [=url/fragment=] or the empty string if the value is null.
@@ -1725,7 +1727,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   1. Let |dummyURL| be a new [=URL record=].
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=hostname state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
-  1. Return |dummyURL|'s [=url/host=].
+  1. Return |dummyURL|'s [=url/host=], [=host serializer|serialized=], or empty string if it is null.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This PR fix missing serialization steps of internal port and host properties in the spec. The URL parser return port as an integer and host as either a hostname string, an integer (IPv4 address) or an array of integers (IPv6 address). For further processing by the URLPattern code these properties need to be properly converted to string.
 
The issue was discussed here: https://github.com/whatwg/urlpattern/issues/202#issuecomment-1937770488


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/224.html" title="Last updated on Apr 17, 2024, 10:03 AM UTC (0962aa9)">Preview</a> | <a href="https://whatpr.org/urlpattern/224/39214ea...0962aa9.html" title="Last updated on Apr 17, 2024, 10:03 AM UTC (0962aa9)">Diff</a>