### PR TITLE
Editorial: Mark IDs referred to by IETF documents as required

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -7,6 +7,7 @@ Text Macro: LATESTRD 2024-03
 Abstract: The URL Pattern Standard provides a web platform primitive for matching URLs based on a convenient pattern syntax.
 Indent: 2
 Markup Shorthands: markdown yes
+Required IDs: url-pattern,url-pattern-create,url-pattern-match,url-pattern-has-regexp-groups
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
Per https://whatwg.org/working-mode#anchors this is being done to ensure anchors to these concepts continue to work into the future.

Resolves #231.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/233.html" title="Last updated on Aug 28, 2024, 8:33 PM UTC (e8476b4)">Preview</a> | <a href="https://whatpr.org/urlpattern/233/d13ebea...e8476b4.html" title="Last updated on Aug 28, 2024, 8:33 PM UTC (e8476b4)">Diff</a>