### PR TITLE
Expose URLPattern everywhere

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -404,6 +404,7 @@ Contributions and review provided by:
 * Kenji Baheux
 * L. David Baron
 * Ralph Chelala
+* Philip Chimento
 * Kenneth Rohde Christiansen
 * Victor Costan
 * Domenic Denicola

--- a/spec.bs
+++ b/spec.bs
@@ -183,7 +183,7 @@ It can be constructed using a string for each component, or from a shorthand str
 <xmp class="idl">
 typedef (USVString or URLPatternInit) URLPatternInput;
 
-[Exposed=(Window,Worker)]
+[Exposed=*]
 interface URLPattern {
   constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
   constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});


### PR DESCRIPTION
I've drafted a set of criteria for which interfaces to expose universally on all globals, at
https://github.com/w3ctag/design-principles/pull/510. URLPattern looks like it fits those criteria and is useful to have in any environment.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * kenchris/urlpattern-polyfill: N/A
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
