### PR TITLE
Correct condition for opaque paths in base URL

### DIFF
--- a/review-drafts/2024-03.bs
+++ b/review-drafts/2024-03.bs
@@ -1868,7 +1868,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If the following are all true:
       <ul>
         <li>|baseURL| is not null;</li>
-        <li>|baseURL| has an [=url/opaque path=]; and</li>
+        <li>|baseURL| does not have an [=url/opaque path=]; and</li>
         <li>the result of running [=is an absolute pathname=] given |result|["{{URLPatternInit/pathname}}"] and |type| is false,
       </ul>
       <p>then:


### PR DESCRIPTION
This fixes one of the test conditions. Relevant Ada URL change https://github.com/ada-url/ada/pull/785/commits/da9a99118b63b60a67f41abf348daf0025783df0

Fixes https://github.com/whatwg/urlpattern/issues/240

cc @jeremyroman @sisidovski 