### PR TITLE
Correct condition for opaque paths in base URL

### DIFF
--- a/review-drafts/2024-03.bs
+++ b/review-drafts/2024-03.bs
@@ -1868,7 +1868,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If the following are all true:
       <ul>
         <li>|baseURL| is not null;</li>
-        <li>|baseURL| does not have an [=url/opaque path=]; and</li>
+        <li>|baseURL| has an [=url/opaque path=]; and</li>
         <li>the result of running [=is an absolute pathname=] given |result|["{{URLPatternInit/pathname}}"] and |type| is false,
       </ul>
       <p>then:

--- a/spec.bs
+++ b/spec.bs
@@ -1883,7 +1883,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If the following are all true:
       <ul>
         <li>|baseURL| is not null;</li>
-        <li>|baseURL| has an [=url/opaque path=]; and</li>
+        <li>|baseURL| does not have an [=url/opaque path=]; and</li>
         <li>the result of running [=is an absolute pathname=] given |result|["{{URLPatternInit/pathname}}"] and |type| is false,
       </ul>
       <p>then:


### PR DESCRIPTION
This PR fixes pathname processing for inputs that have opaque pathnames.

(Amended by editor to apply to the correct draft.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/245.html" title="Last updated on Jan 7, 2025, 9:57 PM UTC (a1f8005)">Preview</a> | <a href="https://whatpr.org/urlpattern/245/2a2f2c3...a1f8005.html" title="Last updated on Jan 7, 2025, 9:57 PM UTC (a1f8005)">Diff</a>