### PR TITLE
Editorial: Fix RFC2119 keyword warnings

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -134,8 +134,8 @@ It can be constructed using a string for each component, or from a [[#constructo
   </ul>
 
   This is a more complicated pattern which includes:
-  * [=part/modifier/optional=] parts marked with `?` (braces are needed to make it unambiguous exactly what is optional), and
-  * a [=part/type/regexp=] part named "`id`" which uses a regular expression to define what sorts of substrings match (the parentheses are required to mark it as a regular expression, and are not part of the regexp itself).
+  * <a for=part/modifier><span class="allow-2119">optional</span></a> parts marked with `?` (braces are needed to make it unambiguous exactly what is <span class="allow-2119">optional</span>), and
+  * a [=part/type/regexp=] part named "`id`" which uses a regular expression to define what sorts of substrings match (the parentheses are necessary to mark it as a regular expression, and are not part of the regexp itself).
 </div>
 
 <div class="example" id="example-intro-3">
@@ -2080,7 +2080,7 @@ Specifications for HTTP headers should operate on [=URL patterns=] (e.g., using 
   1. Return the result of [=creating=] a URL pattern given |rawPattern|, |serializedBaseURL|, and an empty [=map=].
 </div>
 
-<div class="note">Specifications might consider accepting only patterns which do not [=URL pattern/has regexp groups|have regexp groups=] if evaluating the pattern, since the performance of such patterns might be more reliable, and may not require a [[ECMA-262]] regular expression implementation, which may have security, code size, or other implications for implementations. On the other hand, JavaScript APIs run in environments where such an implementation is readily available.</div>
+<div class="note">Specifications might consider accepting only patterns which do not [=URL pattern/has regexp groups|have regexp groups=] if evaluating the pattern, since the performance of such patterns might be more reliable, and might not require a [[ECMA-262]] regular expression implementation, which might have security, code size, or other implications for implementations. On the other hand, JavaScript APIs run in environments where such an implementation is readily available.</div>
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>
 


### PR DESCRIPTION
`optional` is the name of modifier in the spec, soI think it's hard to avoid in some cases.

Fixes #246 