### PR TITLE
Use the basic URL parser when parsing URLs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -513,10 +513,10 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. If |input| is a {{USVString}}:
       1. Let |baseURL| be null.
       1. If |baseURLString| was given, then:
-        1. Set |baseURL| to the result of [=basic URL parser|parsing=] |baseURLString|.
+        1. Set |baseURL| to the result of running the [=basic URL parser=] on |baseURLString|.
         1. If |baseURL| is failure, return null.
         1. [=list/Append=] |baseURLString| to |inputs|.
-      1. Set |url| to the result of [=basic URL parser|parsing=] |input| given |baseURL|.
+      1. Set |url| to the result of running the [=basic URL parser=] on |input| with |baseURL|.
       1. If |url| is failure, return null.
     1. [=Assert=]: |url| is a [=/URL=].
     1. Set |protocol| to |url|'s [=url/scheme=].
@@ -1852,7 +1852,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
 
       Username and password are also never inherited from a base URL when constructing a {{URLPattern}}. (They are, however, inherited from the base URL when parsing a URL supplied as an argument to {{URLPattern/test()}} or {{URLPattern/exec()}}.)
     </div>
-    1. Set |baseURL| to the result of [=basic URL parser|parsing=] |init|["{{URLPatternInit/baseURL}}"].
+    1. Set |baseURL| to the result of running the [=basic URL parser=] on |init|["{{URLPatternInit/baseURL}}"].
     1. If |baseURL| is failure, then throw a {{TypeError}}.
     1. If |init|["{{URLPatternInit/protocol}}"] does not [=map/exist=], then set |result|["{{URLPatternInit/protocol}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/scheme=] and |type|.
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}" and "{{URLPatternInit/username}}", then set |result|["{{URLPatternInit/username}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/username=] and |type|.

--- a/spec.bs
+++ b/spec.bs
@@ -513,10 +513,10 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. If |input| is a {{USVString}}:
       1. Let |baseURL| be null.
       1. If |baseURLString| was given, then:
-        1. Set |baseURL| to the result of [=URL parser|parsing=] |baseURLString|.
+        1. Set |baseURL| to the result of [=basic URL parser|parsing=] |baseURLString|.
         1. If |baseURL| is failure, return null.
         1. [=list/Append=] |baseURLString| to |inputs|.
-      1. Set |url| to the result of [=URL parser|parsing=] |input| given |baseURL|.
+      1. Set |url| to the result of [=basic URL parser|parsing=] |input| given |baseURL|.
       1. If |url| is failure, return null.
     1. [=Assert=]: |url| is a [=/URL=].
     1. Set |protocol| to |url|'s [=url/scheme=].
@@ -1852,7 +1852,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
 
       Username and password are also never inherited from a base URL when constructing a {{URLPattern}}. (They are, however, inherited from the base URL when parsing a URL supplied as an argument to {{URLPattern/test()}} or {{URLPattern/exec()}}.)
     </div>
-    1. Set |baseURL| to the result of [=URL parser|parsing=] |init|["{{URLPatternInit/baseURL}}"].
+    1. Set |baseURL| to the result of [=basic URL parser|parsing=] |init|["{{URLPatternInit/baseURL}}"].
     1. If |baseURL| is failure, then throw a {{TypeError}}.
     1. If |init|["{{URLPatternInit/protocol}}"] does not [=map/exist=], then set |result|["{{URLPatternInit/protocol}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/scheme=] and |type|.
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}" and "{{URLPatternInit/username}}", then set |result|["{{URLPatternInit/username}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/username=] and |type|.


### PR DESCRIPTION
Blob handling is not required, since the resulting URL is not stored in any way that would make the blob handling visible. This is consistent with what the URL constructor and similar uses do.

This change should not be observable.

Partially addresses #242.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/248.html" title="Last updated on Jan 8, 2025, 10:03 PM UTC (8c660ed)">Preview</a> | <a href="https://whatpr.org/urlpattern/248/807258f...8c660ed.html" title="Last updated on Jan 8, 2025, 10:03 PM UTC (8c660ed)">Diff</a>