### PR TITLE
Editorial: Correct a "set" to "let"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1329,7 +1329,7 @@ To <dfn>parse a pattern string</dfn> given a [=/pattern string=] |input|, [=/opt
       1. Set |regexp or wildcard token| to the result of running [=try to consume a regexp or wildcard token=] given |parser| and |name token|.
       1. Let |suffix| be the result of running [=consume text=] given |parser|.
       1. Run [=consume a required token=] given |parser| and "<a for=token/type>`close`</a>".
-      1. Set |modifier token| to the result of running [=try to consume a modifier token=] given |parser|.
+      1. Let |modifier token| be the result of running [=try to consume a modifier token=] given |parser|.
       1. Run [=add a part=] given |parser|, |prefix|, |name token|, |regexp or wildcard token|, |suffix|, and |modifier token|.
       1. [=Continue=].
     1. Run [=maybe add a part from the pending fixed value=] given |parser|.

--- a/spec.bs
+++ b/spec.bs
@@ -1324,7 +1324,7 @@ To <dfn>parse a pattern string</dfn> given a [=/pattern string=] |input|, [=/opt
         </dl>
       </div>
     1. If |open token| is not null:
-      1. Set |prefix| be the result of running [=consume text=] given |parser|.
+      1. Let |prefix| be the result of running [=consume text=] given |parser|.
       1. Set |name token| to the result of running [=try to consume a token=] given |parser| and "<a for=token/type>`name`</a>".
       1. Set |regexp or wildcard token| to the result of running [=try to consume a regexp or wildcard token=] given |parser| and |name token|.
       1. Let |suffix| be the result of running [=consume text=] given |parser|.


### PR DESCRIPTION
This use introduces the variable, so it must be "set" (and grammatically it didn't make sense before, so this is merely a typo).

Partially addresses #242.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/249.html" title="Last updated on Jan 9, 2025, 3:40 PM UTC (06d924d)">Preview</a> | <a href="https://whatpr.org/urlpattern/249/807258f...06d924d.html" title="Last updated on Jan 9, 2025, 3:40 PM UTC (06d924d)">Diff</a>