### PR TITLE
Serialize base URL's host when a string is required

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1858,7 +1858,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}" and "{{URLPatternInit/username}}", then set |result|["{{URLPatternInit/username}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/username=] and |type|.
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}", "{{URLPatternInit/username}}" and "{{URLPatternInit/password}}", then set |result|["{{URLPatternInit/password}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/password=] and |type|.
     1. If |init| [=map/contains=] neither "{{URLPatternInit/protocol}}" nor "{{URLPatternInit/hostname}}", then:
-      1. Let |baseHost| be |baseURL|'s [=url/host=].
+      1. Let |baseHost| be the [=host serializer|serialization=] of |baseURL|'s [=url/host=].
       1. If |baseHost| is null, then set |baseHost| to the empty string.
       1. Set |result|["{{URLPatternInit/hostname}}"] to the result of [=processing a base URL string=] given |baseHost| and |type|.
     1. If |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", and "{{URLPatternInit/port}}", then:


### PR DESCRIPTION
If the URL's host is an IP address, the string representation is required.

This corrects/clarifies existing behavior and partially resolves #242.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/250.html" title="Last updated on Jan 8, 2025, 9:44 PM UTC (a5b70be)">Preview</a> | <a href="https://whatpr.org/urlpattern/250/807258f...a5b70be.html" title="Last updated on Jan 8, 2025, 9:44 PM UTC (a5b70be)">Diff</a>