### PR TITLE
Correct null handling when computing base URL host string

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1858,7 +1858,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}" and "{{URLPatternInit/username}}", then set |result|["{{URLPatternInit/username}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/username=] and |type|.
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}", "{{URLPatternInit/username}}" and "{{URLPatternInit/password}}", then set |result|["{{URLPatternInit/password}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/password=] and |type|.
     1. If |init| [=map/contains=] neither "{{URLPatternInit/protocol}}" nor "{{URLPatternInit/hostname}}", then:
-      1. Let |baseHost| be the [=host serializer|serialization=] of |baseURL|'s [=url/host=], if it is not null, and the empty string otherwise.
+      1. Let |baseHost| be the empty string.
+      1. If |baseURL|'s [=url/host=] is not null, then set |baseHost| to its [=host serializer|serialization=].
       1. Set |result|["{{URLPatternInit/hostname}}"] to the result of [=processing a base URL string=] given |baseHost| and |type|.
     1. If |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", and "{{URLPatternInit/port}}", then:
       1. If |baseURL|'s [=url/port=] is null, then set |result|["{{URLPatternInit/port}}"] to the empty string.

--- a/spec.bs
+++ b/spec.bs
@@ -1858,8 +1858,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}" and "{{URLPatternInit/username}}", then set |result|["{{URLPatternInit/username}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/username=] and |type|.
     1. If |type| is not "`pattern`" and |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", "{{URLPatternInit/port}}", "{{URLPatternInit/username}}" and "{{URLPatternInit/password}}", then set |result|["{{URLPatternInit/password}}"] to the result of [=processing a base URL string=] given |baseURL|'s [=url/password=] and |type|.
     1. If |init| [=map/contains=] neither "{{URLPatternInit/protocol}}" nor "{{URLPatternInit/hostname}}", then:
-      1. Let |baseHost| be the [=host serializer|serialization=] of |baseURL|'s [=url/host=].
-      1. If |baseHost| is null, then set |baseHost| to the empty string.
+      1. Let |baseHost| be the [=host serializer|serialization=] of |baseURL|'s [=url/host=], if it is not null, and the empty string otherwise.
       1. Set |result|["{{URLPatternInit/hostname}}"] to the result of [=processing a base URL string=] given |baseHost| and |type|.
     1. If |init| [=map/contains=] none of "{{URLPatternInit/protocol}}", "{{URLPatternInit/hostname}}", and "{{URLPatternInit/port}}", then:
       1. If |baseURL|'s [=url/port=] is null, then set |result|["{{URLPatternInit/port}}"] to the empty string.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/251.html" title="Last updated on Jan 15, 2025, 4:14 PM UTC (abf39cf)">Preview</a> | <a href="https://whatpr.org/urlpattern/251/7564e2d...abf39cf.html" title="Last updated on Jan 15, 2025, 4:14 PM UTC (abf39cf)">Diff</a>