### PR TITLE
Remove leading and trailing spaces in the process port for init

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1944,6 +1944,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
 <div algorithm>
   To <dfn>process port for init</dfn> given a string |portValue|, a string |protocolValue|, and a string |type|:
 
+  1. Remove any leading and trailing [=C0 control or space=] from |portValue|.
   1. If |type| is "`pattern`" then return |portValue|.
   1. Return the result of running [=canonicalize a port=] given |portValue| and |protocolValue|.
 </div>


### PR DESCRIPTION
This will address https://github.com/whatwg/urlpattern/issues/260.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/261.html" title="Last updated on Mar 12, 2025, 11:35 AM UTC (1dc7e72)">Preview</a> | <a href="https://whatpr.org/urlpattern/261/c289ec2...1dc7e72.html" title="Last updated on Mar 12, 2025, 11:35 AM UTC (1dc7e72)">Diff</a>