### PR TITLE
Review Draft Publication: March 2025

### DIFF
--- a/review-drafts/2025-03.bs
+++ b/review-drafts/2025-03.bs
@@ -1,5 +1,7 @@
 <pre class="metadata">
 Group: WHATWG
+Status: RD
+Date: 2025-03-17
 H1: URL Pattern
 Shortname: urlpattern
 Text Macro: TWITTER urlpatterns


### PR DESCRIPTION
The [March 2025 Review Draft](https://urlpattern.spec.whatwg.org/review-drafts/2025-03/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.