### PR TITLE
Append the serialization of URL to inputs when performing a match

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -496,7 +496,10 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Let |search| be the empty string.
   1. Let |hash| be the empty string.
   1. Let |inputs| be an empty [=list=].
-  1. [=list/Append=] |input| to |inputs|.
+  1. If |input| is a {{URL}}:
+    1. [=list/Append=] the [=URL serializer|serialization=] of |input| to |inputs|.
+  1. Otherwise:
+    1. [=list/Append=] |input| to |inputs|.
   1. If |input| is a {{URLPatternInit}} then:
     1. If |baseURLString| was given, throw a {{TypeError}}.
     1. Let |applyResult| be the result of [=process a URLPatternInit=] given |input|, "url", |protocol|, |username|, |password|, |hostname|, |port|, |pathname|, |search|, and |hash|. If this throws an exception, catch it, and return null.

--- a/spec.bs
+++ b/spec.bs
@@ -496,10 +496,8 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Let |search| be the empty string.
   1. Let |hash| be the empty string.
   1. Let |inputs| be an empty [=list=].
-  1. If |input| is a {{URL}}:
-    1. [=list/Append=] the [=URL serializer|serialization=] of |input| to |inputs|.
-  1. Otherwise:
-    1. [=list/Append=] |input| to |inputs|.
+  1. If |input| is a [=/URL=], then [=list/append=] the [=URL serializer|serialization=] of |input| to |inputs|.
+  1. Otherwise, [=list/append=] |input| to |inputs|.
   1. If |input| is a {{URLPatternInit}} then:
     1. If |baseURLString| was given, throw a {{TypeError}}.
     1. Let |applyResult| be the result of [=process a URLPatternInit=] given |input|, "url", |protocol|, |username|, |password|, |hostname|, |port|, |pathname|, |search|, and |hash|. If this throws an exception, catch it, and return null.


### PR DESCRIPTION
The list `inputs` is an array of `URLPatternInput` which can only
be either a `USVString` or a `URLPatternInit`. To handle the case
where a URL is passed through, we need to append the serialization
of that URL.

This was the source of my confusion in https://github.com/whatwg/urlpattern/issues/264 as I was thinking it could only be a URLPatternInput.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * kenchris/urlpattern-polyfill: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/265.html" title="Last updated on Mar 22, 2025, 2:02 AM UTC (a5289a5)">Preview</a> | <a href="https://whatpr.org/urlpattern/265/20b4d3a...a5289a5.html" title="Last updated on Mar 22, 2025, 2:02 AM UTC (a5289a5)">Diff</a>