### PR TITLE
Make dummyURL from the basic URL parser with a special scheme

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1721,7 +1721,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a username</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. [=Set the username=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/username=].
 </div>
@@ -1730,7 +1730,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a password</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. [=Set the password=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/password=].
 </div>
@@ -1739,7 +1739,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hostname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=hostname state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
   1. Return |dummyURL|'s [=url/host=], [=host serializer|serialized=], or empty string if it is null.
@@ -1766,7 +1766,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a port</dfn> given a string |portValue| and optionally a string |protocolValue|:
 
   1. If |portValue| is the empty string, return |portValue|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. If |protocolValue| was given, then set |dummyURL|'s [=url/scheme=] to |protocolValue|.
      <p class="note">Note, we set the [=URL record=]'s [=url/scheme=] in order for the [=basic URL parser=] to recognize and normalize default port values.</p>
   1. Let |parseResult| be the result of running [=basic URL parser=] given |portValue| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=port state=] as <i>[=basic URL parser/state override=]</i>.
@@ -1785,7 +1785,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
       <p>Note, implementations are free to simply disable slash prepending in their URL parsing code instead of paying the performance penalty of inserting and removing characters in this algorithm.
     </div>
   1. Append |value| to the end of |modified value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. Run [=basic URL parser=] given |modified value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. Let |result| be the result of [=URL path serializing=] |dummyURL|.
   1. If |leading slash| is false, then set |result| to the [=code point substring to the end of the string|code point substring=] from 2 to the end of the string within |result|.
@@ -1796,7 +1796,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize an opaque pathname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. Set |dummyURL|'s [=url/path=] to the empty string.
   1. Let |parseResult| be the result of running [=basic URL parser|URL parsing=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=basic URL parser/opaque path state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
@@ -1807,7 +1807,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a search</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. Set |dummyURL|'s [=url/query=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=query state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/query=].
@@ -1817,7 +1817,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hash</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=creating a dummy URL=].
   1. Set |dummyURL|'s [=url/fragment=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=fragment state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/fragment=].

--- a/spec.bs
+++ b/spec.bs
@@ -564,13 +564,6 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Return false.
 </div>
 
-<div algorithm>
-  To <dfn export for="URL pattern">create a dummy URL</dfn>:
-
-  1. Let |dummyInput| be "`https://dummy.invalid/`".
-  1. Return the result of running the [=basic URL parser=] on |dummyInput|.
-</div>
-
 <h3 id=urlpattern-internals>Internals</h3>
 
 <div algorithm>
@@ -604,6 +597,13 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
     1. Increment |index| by 1.
   1. Set |result|["{{URLPatternComponentResult/groups}}"] to |groups|.
   1. Return |result|.
+</div>
+
+<div algorithm>
+  To <dfn export for="URL pattern">create a dummy URL</dfn>:
+
+  1. Let |dummyInput| be "`https://dummy.invalid/`".
+  1. Return the result of running the [=basic URL parser=] on |dummyInput|.
 </div>
 
 The <dfn>default options</dfn> is an [=options=] [=struct=] with [=options/delimiter code point=] set to the empty string and [=options/prefix code point=] set to the empty string.
@@ -1711,7 +1711,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a protocol</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| followed by "`://dummy.invalid`".
+  1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| followed by "`://dummy.invalid/`".
      <p class="note">Note, [=basic URL parser/state override=] is not used here because it enforces restrictions that are only appropriate for the {{URL/protocol}} setter.  Instead we use the protocol to parse a dummy URL using the normal parsing entry point.</p>
   1. If |parseResult| is failure, then throw a {{TypeError}}.
   1. Return |parseResult|'s [=url/scheme=].
@@ -1721,7 +1721,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a username</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. [=Set the username=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/username=].
 </div>
@@ -1730,7 +1730,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a password</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. [=Set the password=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/password=].
 </div>
@@ -1739,7 +1739,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hostname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=hostname state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
   1. Return |dummyURL|'s [=url/host=], [=host serializer|serialized=], or empty string if it is null.
@@ -1766,7 +1766,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a port</dfn> given a string |portValue| and optionally a string |protocolValue|:
 
   1. If |portValue| is the empty string, return |portValue|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. If |protocolValue| was given, then set |dummyURL|'s [=url/scheme=] to |protocolValue|.
      <p class="note">Note, we set the [=URL record=]'s [=url/scheme=] in order for the [=basic URL parser=] to recognize and normalize default port values.</p>
   1. Let |parseResult| be the result of running [=basic URL parser=] given |portValue| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=port state=] as <i>[=basic URL parser/state override=]</i>.
@@ -1785,7 +1785,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
       <p>Note, implementations are free to simply disable slash prepending in their URL parsing code instead of paying the performance penalty of inserting and removing characters in this algorithm.
     </div>
   1. Append |value| to the end of |modified value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. Run [=basic URL parser=] given |modified value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. Let |result| be the result of [=URL path serializing=] |dummyURL|.
   1. If |leading slash| is false, then set |result| to the [=code point substring to the end of the string|code point substring=] from 2 to the end of the string within |result|.
@@ -1796,7 +1796,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize an opaque pathname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/path=] to the empty string.
   1. Let |parseResult| be the result of running [=basic URL parser|URL parsing=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=basic URL parser/opaque path state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
@@ -1807,7 +1807,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a search</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/query=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=query state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/query=].
@@ -1817,7 +1817,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hash</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
+  1. Let |dummyURL| be the result of [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/fragment=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=fragment state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/fragment=].

--- a/spec.bs
+++ b/spec.bs
@@ -564,6 +564,13 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Return false.
 </div>
 
+<div algorithm>
+  To <dfn export for="URL pattern">create a dummy URL</dfn>:
+
+  1. Let |dummyInput| be "`https://dummy.invalid/`".
+  1. Return the result of running the [=basic URL parser=] on |dummyInput|.
+</div>
+
 <h3 id=urlpattern-internals>Internals</h3>
 
 <div algorithm>
@@ -1704,20 +1711,17 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a protocol</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
-  1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| followed by "`://dummy.test`", with |dummyURL| as <i>[=basic URL parser/url=]</i>.
+  1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| followed by "`://dummy.invalid`".
      <p class="note">Note, [=basic URL parser/state override=] is not used here because it enforces restrictions that are only appropriate for the {{URL/protocol}} setter.  Instead we use the protocol to parse a dummy URL using the normal parsing entry point.</p>
   1. If |parseResult| is failure, then throw a {{TypeError}}.
-  1. Return |dummyURL|'s [=url/scheme=].
+  1. Return |parseResult|'s [=url/scheme=].
 </div>
 
 <div algorithm>
   To <dfn>canonicalize a username</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. [=Set the username=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/username=].
 </div>
@@ -1726,8 +1730,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a password</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. [=Set the password=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/password=].
 </div>
@@ -1736,8 +1739,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hostname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=hostname state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
   1. Return |dummyURL|'s [=url/host=], [=host serializer|serialized=], or empty string if it is null.
@@ -1764,8 +1766,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a port</dfn> given a string |portValue| and optionally a string |protocolValue|:
 
   1. If |portValue| is the empty string, return |portValue|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. If |protocolValue| was given, then set |dummyURL|'s [=url/scheme=] to |protocolValue|.
      <p class="note">Note, we set the [=URL record=]'s [=url/scheme=] in order for the [=basic URL parser=] to recognize and normalize default port values.</p>
   1. Let |parseResult| be the result of running [=basic URL parser=] given |portValue| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=port state=] as <i>[=basic URL parser/state override=]</i>.
@@ -1784,8 +1785,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
       <p>Note, implementations are free to simply disable slash prepending in their URL parsing code instead of paying the performance penalty of inserting and removing characters in this algorithm.
     </div>
   1. Append |value| to the end of |modified value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. Run [=basic URL parser=] given |modified value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. Let |result| be the result of [=URL path serializing=] |dummyURL|.
   1. If |leading slash| is false, then set |result| to the [=code point substring to the end of the string|code point substring=] from 2 to the end of the string within |result|.
@@ -1796,8 +1796,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize an opaque pathname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/path=] to the empty string.
   1. Let |parseResult| be the result of running [=basic URL parser|URL parsing=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=basic URL parser/opaque path state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
@@ -1808,8 +1807,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a search</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/query=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=query state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/query=].
@@ -1819,8 +1817,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hash</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyInput| be "http://dummy.test".
-  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
+  1. Let |dummyURL| be the result of running the [=create a dummy URL=].
   1. Set |dummyURL|'s [=url/fragment=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=fragment state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/fragment=].

--- a/spec.bs
+++ b/spec.bs
@@ -1704,7 +1704,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a protocol</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| followed by "`://dummy.test`", with |dummyURL| as <i>[=basic URL parser/url=]</i>.
      <p class="note">Note, [=basic URL parser/state override=] is not used here because it enforces restrictions that are only appropriate for the {{URL/protocol}} setter.  Instead we use the protocol to parse a dummy URL using the normal parsing entry point.</p>
   1. If |parseResult| is failure, then throw a {{TypeError}}.
@@ -1715,7 +1716,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a username</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. [=Set the username=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/username=].
 </div>
@@ -1724,7 +1726,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a password</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. [=Set the password=] given |dummyURL| and |value|.
   1. Return |dummyURL|'s [=url/password=].
 </div>
@@ -1733,7 +1736,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hostname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Let |parseResult| be the result of running the [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=hostname state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
   1. Return |dummyURL|'s [=url/host=], [=host serializer|serialized=], or empty string if it is null.
@@ -1760,7 +1764,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a port</dfn> given a string |portValue| and optionally a string |protocolValue|:
 
   1. If |portValue| is the empty string, return |portValue|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. If |protocolValue| was given, then set |dummyURL|'s [=url/scheme=] to |protocolValue|.
      <p class="note">Note, we set the [=URL record=]'s [=url/scheme=] in order for the [=basic URL parser=] to recognize and normalize default port values.</p>
   1. Let |parseResult| be the result of running [=basic URL parser=] given |portValue| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=port state=] as <i>[=basic URL parser/state override=]</i>.
@@ -1779,7 +1784,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
       <p>Note, implementations are free to simply disable slash prepending in their URL parsing code instead of paying the performance penalty of inserting and removing characters in this algorithm.
     </div>
   1. Append |value| to the end of |modified value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Run [=basic URL parser=] given |modified value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. Let |result| be the result of [=URL path serializing=] |dummyURL|.
   1. If |leading slash| is false, then set |result| to the [=code point substring to the end of the string|code point substring=] from 2 to the end of the string within |result|.
@@ -1790,7 +1796,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize an opaque pathname</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Set |dummyURL|'s [=url/path=] to the empty string.
   1. Let |parseResult| be the result of running [=basic URL parser|URL parsing=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=basic URL parser/opaque path state=] as <i>[=basic URL parser/state override=]</i>.
   1. If |parseResult| is failure, then throw a {{TypeError}}.
@@ -1801,7 +1808,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a search</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Set |dummyURL|'s [=url/query=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=query state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/query=].
@@ -1811,7 +1819,8 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
   To <dfn>canonicalize a hash</dfn> given a string |value|:
 
   1. If |value| is the empty string, return |value|.
-  1. Let |dummyURL| be a new [=URL record=].
+  1. Let |dummyInput| be "http://dummy.test".
+  1. Let |dummyURL| be the result of running the [=basic URL parser=] on |dummyInput|.
   1. Set |dummyURL|'s [=url/fragment=] to the empty string.
   1. Run [=basic URL parser=] given |value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=fragment state=] as <i>[=basic URL parser/state override=]</i>.
   1. Return |dummyURL|'s [=url/fragment=].


### PR DESCRIPTION
<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Based on the discussion in https://github.com/whatwg/urlpattern/issues/252.

We should not use URL records directly to canonicalize components, we should specify a special scheme as a default scheme. When we create a dummy URL, it should be created from the basic URL parser. This is not ideal but this can be achieved by creating a dummy URL with this fixed URL string.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/269.html" title="Last updated on Mar 25, 2025, 2:08 PM UTC (9105e2f)">Preview</a> | <a href="https://whatpr.org/urlpattern/269/5c979a3...9105e2f.html" title="Last updated on Mar 25, 2025, 2:08 PM UTC (9105e2f)">Diff</a>