### PR TITLE
Empty dummyURL's path before URL parsing in pathname canonicalization

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1786,6 +1786,7 @@ To <dfn>convert a modifier to a string</dfn> given a [=part/modifier=] |modifier
     </div>
   1. Append |value| to the end of |modified value|.
   1. Let |dummyURL| be the result of [=creating a dummy URL=].
+  1. [=list/Empty=] |dummyURL|'s [=url/path=].
   1. Run [=basic URL parser=] given |modified value| with |dummyURL| as <i>[=basic URL parser/url=]</i> and [=path start state=] as <i>[=basic URL parser/state override=]</i>.
   1. Let |result| be the result of [=URL path serializing=] |dummyURL|.
   1. If |leading slash| is false, then set |result| to the [=code point substring to the end of the string|code point substring=] from 2 to the end of the string within |result|.


### PR DESCRIPTION
Which prevents dummy URL's pathname from being included in the beginning of the new pathname.

Fixes: #271

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno: …
   * kenchris/urlpattern-polyfill: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/urlpattern/272.html" title="Last updated on Mar 26, 2025, 6:50 AM UTC (3a137db)">Preview</a> | <a href="https://whatpr.org/urlpattern/272/46c30fd...3a137db.html" title="Last updated on Mar 26, 2025, 6:50 AM UTC (3a137db)">Diff</a>