### PR TITLE
Limit component match result iteration to group name list size

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -595,7 +595,7 @@ A <dfn>component</dfn> is a [=struct=] with the following [=struct/items=]:
   1. Set |result|["{{URLPatternComponentResult/input}}"] to |input|.
   1. Let |groups| be a <code>[=record=]<{{USVString}}, ({{USVString}} or {{undefined}})></code>.
   1. Let |index| be 1.
-  1. While |index| is less than [$Get$](|execResult|, "`length`"):
+  1. While |index| is less than or equal to |component|'s [=component/group name list=]'s [=list/size=]:
     1. Let |name| be |component|'s [=component/group name list=][|index| &minus; 1].
     1. Let |value| be [$Get$](|execResult|, [$ToString$](|index|)).
     1. Set |groups|[|name|] to |value|.


### PR DESCRIPTION
User-provided regexp parts may contain nested capturing groups, causing execResult to contain more captures than there are URLPattern groups.

<!--
Thank you for contributing to the URL Pattern Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Multiple implementations already implement
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/cfce2c045229bb078cb363298f52b3ea0a31acd7/urlpattern/resources/urlpatterntestdata.json#L3146 (specifically see the last commit from gecko)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Seems already implemented
   * Gecko: Already patched
   * WebKit: Looks like they have patched this
   * Deno: Seems already implemented
   * kenchris/urlpattern-polyfill: Already implemented
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
